### PR TITLE
More tests for TLSPlaintext record parser

### DIFF
--- a/tls/test/test_record.py
+++ b/tls/test/test_record.py
@@ -40,10 +40,10 @@ class TestRecordParsing(object):
         """
         packet = (
             b'\x1a'  # invalid type
-            + b'\x03'
-            + b'\x03'
-            + b'\x00\x0A'
-            + b'0123456789'
+            b'\x03'
+            b'\x03'
+            b'\x00\x0A'
+            b'0123456789'
         )
         with pytest.raises(ValueError) as exc_info:
             parse_tls_plaintext(packet)
@@ -55,9 +55,9 @@ class TestRecordParsing(object):
         """
         packet = (
             b'\x16'  # type
-            + b'\x03'  # minor version
-            + b'\x00\x0A'  # big-endian length
-            + b'0123456789'  # fragment
+            b'\x03'  # minor version
+            b'\x00\x0A'  # big-endian length
+            b'0123456789'  # fragment
         )
         with pytest.raises(FieldError) as exc_info:
             parse_tls_plaintext(packet)
@@ -69,10 +69,10 @@ class TestRecordParsing(object):
         """
         packet = (
             b'\x16'  # type
-            + b'\x03'  # major version
-            + b'\x03'  # minor version
-            + b'\x00\x0A'  # big-endian length
-            + b'12'  # fragment
+            b'\x03'  # major version
+            b'\x03'  # minor version
+            b'\x00\x0A'  # big-endian length
+            b'12'  # fragment
         )
         with pytest.raises(FieldError) as exc_info:
             parse_tls_plaintext(packet)


### PR DESCRIPTION
Some negative tests.

This needs to be updated after @radix's #5 is merged.
