### PR TITLE
Remove requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-characteristic
-construct
-enum34


### PR DESCRIPTION
We don't actually need this. The required packages are already specified in `setup.py` and installing the package with `pip install --editable .` during development will pull it down. Duplicate information is always bad.
