### PR TITLE
get rid of length attribute from our packet objects

### DIFF
--- a/tls/record.py
+++ b/tls/record.py
@@ -12,14 +12,14 @@ class ProtocolVersion(object):
     """
 
 
-@attributes(['type', 'version', 'length', 'fragment'])
+@attributes(['type', 'version', 'fragment'])
 class TLSPlaintext(object):
     """
     An object representing a TLSPlaintext struct.
     """
 
 
-@attributes(['type', 'version', 'length', 'fragment'])
+@attributes(['type', 'version', 'fragment'])
 class TLSCompressed(object):
     """
     An object representing a TLSCompressed struct.
@@ -46,7 +46,6 @@ def parse_tls_plaintext(bytes):
         version=ProtocolVersion(
             major=construct.version.major,
             minor=construct.version.minor),
-        length=construct.length,
         fragment=construct.fragment)
 
 
@@ -63,5 +62,4 @@ def parse_tls_compressed(bytes):
         version=ProtocolVersion(
             major=construct.version.major,
             minor=construct.version.minor),
-        length=construct.length,
         fragment=construct.fragment)

--- a/tls/test/test_record.py
+++ b/tls/test/test_record.py
@@ -31,7 +31,6 @@ class TestTLSPlaintextParsing(object):
         assert record.type == ContentType.HANDSHAKE
         assert record.version.major == 3
         assert record.version.minor == 3
-        assert record.length == 10
         assert record.fragment == b'0123456789'
 
     def test_parse_tls_plaintext_wrong_type(self):
@@ -100,7 +99,6 @@ class TestTLSCompressedParsing(object):
         assert record.type == ContentType.HANDSHAKE
         assert record.version.major == 3
         assert record.version.minor == 3
-        assert record.length == 10
         assert record.fragment == b'0123456789'
 
     def test_parse_tls_compressed_wrong_type(self):


### PR DESCRIPTION
it's unnecessary after parsing
