### PR TITLE
Typo in setting up constructs for TLSCiphertext

### DIFF
--- a/tls/_constructs.py
+++ b/tls/_constructs.py
@@ -26,7 +26,7 @@ TLSCompressed = Struct(
 )
 
 TLSCiphertext = Struct(
-    "TLSCompressed",
+    "TLSCiphertext",
     UBInt8("type"),
     ProtocolVersion,
     UBInt16("length"),  # TODO: Reject packets with length > 2 ** 14 + 2048


### PR DESCRIPTION
I know they both start with a 'C' and look kinda similar, but...
