### PR TITLE
Add an ignore path for doc8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
     sphinx-build -W -b latex -d {envtmpdir}/doctrees docs docs/_build/latex
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
     sphinx-build -W -b spelling docs docs/_build/html
-    doc8 README.rst docs/
+    doc8 README.rst docs/ --ignore-path docs/_build/
 
 [testenv:docs-linkcheck]
 deps =


### PR DESCRIPTION
This should fix the failing builds.
