### PR TITLE
Remove hardcoded length in TLSPrefixedArray

### DIFF
--- a/tls/_common/_constructs.py
+++ b/tls/_common/_constructs.py
@@ -112,7 +112,7 @@ def TLSPrefixedArray(name, subcon, length_validator=None,  # noqa
     return construct.TunnelAdapter(
         PrefixedBytes(name,
                       length_field=length_field),
-        construct.Range(0, 2 ** 16 - 1, subcon)
+        construct.Range(0, 2 ** (length_field.sizeof() * 8) - 1, subcon)
     )
 
 

--- a/tls/_common/test/test_constructs.py
+++ b/tls/_common/test/test_constructs.py
@@ -341,7 +341,8 @@ class TestTLSPrefixedArrayWithDefaultLengthFieldSize(object):
     "ints,uint8_encoded",
     [([], b'\x00\x00\x00' + b''),
      ([1, 2, 3], b'\x00\x00\x03' + b'\x01\x02\x03'),
-     ([1] * 65535, b'\x00\xFF\xFF' + b'\x01' * 65535)])
+     ([1] * 65535, b'\x00\xFF\xFF' + b'\x01' * 65535),
+     ([1] * 16777215, b'\xFF\xFF\xFF' + b'\x01' * 16777215),])
 class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
     """
     Tests for :py:func:`tls._common._constructs.TLSPrefixedArray` where the

--- a/tls/_common/test/test_constructs.py
+++ b/tls/_common/test/test_constructs.py
@@ -342,7 +342,7 @@ class TestTLSPrefixedArrayWithDefaultLengthFieldSize(object):
     [([], b'\x00\x00\x00' + b''),
      ([1, 2, 3], b'\x00\x00\x03' + b'\x01\x02\x03'),
      ([1] * 65535, b'\x00\xFF\xFF' + b'\x01' * 65535),
-     ([1] * 16777215, b'\xFF\xFF\xFF' + b'\x01' * 16777215),])
+     ([1] * 16777215, b'\xFF\xFF\xFF' + b'\x01' * 16777215)])
 class TestTLSPrefixedArrayWithCustomLengthFieldSize(object):
     """
     Tests for :py:func:`tls._common._constructs.TLSPrefixedArray` where the


### PR DESCRIPTION
The current test makes the whole test suite extremely slow, but it was the only test case that reliably failed _before_ my change and passed after. Since the default length is UBInt16, we need something > 2 ** 16 to catch this bug correctly. Everything else either fails with a generic AssertionError on parsing bad values before this bug, or passes. Thoughts?